### PR TITLE
Fix "Failed to read" bower error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "src",
     "examples",
     "zuul.config.js",
-    ".babelrc"
+    ".babelrc",
     "webpack.config.js"
   ]
 }


### PR DESCRIPTION
I think that this comma is the reason for Bower's "Failed to read" error on installation.