### PR TITLE
Update Connection state check

### DIFF
--- a/src/Connection/index.js
+++ b/src/Connection/index.js
@@ -607,7 +607,7 @@ export default class Connection extends Emitter {
    * @return {void}
    */
   write (payload) {
-    if (this.ws.readyState !== window.WebSocket.OPEN) {
+    if (this.ws.readyState !== 1) {
       if (process.env.NODE_ENV !== 'production') {
         debug('connection is not in open state, current state %s', this.ws.readyState)
       }


### PR DESCRIPTION
Currently I am experiencing a bug. When using websocket-client in the browser it will never send a message over the WebSocket connection. This is due to window.WebSocket.OPEN being a function and this will never equal to 1 (the open status).

This currently makes the library unusable, this change should fix it.