### PR TITLE
Returns the Emittery.js response when you call ".on()"

### DIFF
--- a/src/Socket/index.js
+++ b/src/Socket/index.js
@@ -134,7 +134,7 @@ export default class Socket {
    * @method on
    */
   on (...args) {
-    this.emitter.on(...args)
+    return this.emitter.on(...args)
   }
 
   /* istanbul-ignore */


### PR DESCRIPTION
When using socket.off(), it didn't actually remove the event listener, I couldn't figure out why that was, but after some digging, Emittery.js' response for the .on() method, returns the off() method, if we return this response in adonis websocket client, we can store this variable, when we call client.on('message', this.handleMessage); for example, then when we need to remove the event listener, we can just call our reference to this variable again..

This is a quick hacky fix to my solution, that will also solve others problems, but you should probably look into why your .off() method doesnt work correctly.

Here's an example before my fix:

```
let subscription = websocketClient.getSubscription('chat');
subscription.on('message', handleMessage); //You would typically call this in "mounted" or something similar in VueJS

handleMessage() {
    console.log('You have a new message');
}

//When we leave this page in a VueJS SPA we need to remove the listener. 
subscription.off('message', handleMessage);//This would not remove the listener
```


And example after:

```
let subscription = websocketClient.getSubscription('chat');
let onMessageListener = subscription.on('message', handleMessage); //You would typically call this in "mounted" or something similar in VueJS

handleMessage() {
    console.log('You have a new message');
}

//When we leave this page in a VueJS SPA we need to remove the listener. 
onMessageListener();
//Because subscription.on() returns the response of emittery, it's this simple.
```