### PR TITLE
Remove reference to Vue Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@
     <a href="https://adonisjs.com/docs/websocket">
       Official Docs
     </a>
-    <span> | </span>
-    <a href="https://github.com/adonisjs/adonis-websocket-vue">
-      Vue Plugin
-    </a>
   </h3>
 </div>
 


### PR DESCRIPTION
Removes reference to non-existent (or publicly-inaccessible) adonis-websocket-vue repository